### PR TITLE
Add upload API endpoints for banner and local file uploads

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,4 +53,4 @@ next-env.d.ts
 /.output.txt
 
 # Ignore the uploads folder
-uploads/
+public/uploads/**

--- a/src/app/api/uploads/banner/route.ts
+++ b/src/app/api/uploads/banner/route.ts
@@ -1,0 +1,55 @@
+// SPDX-License-Identifier: Apache-2.0
+import { NextRequest } from "next/server";
+import { requireAdmin } from "@/lib/auth";
+import path from "node:path";
+import { promises as fs } from "node:fs";
+import { randomUUID } from "node:crypto";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+const DEFAULT_MAX_IMAGE_BYTES = 5 * 1024 * 1024; // 5MB
+
+export async function POST(req: NextRequest) {
+  try {
+    await requireAdmin();
+
+    // Accept multipart form data
+    const form = await req.formData();
+    const file = form.get("file");
+    if (!(file instanceof File)) {
+      return new Response(JSON.stringify({ ok: false, error: { message: "file required" } }), { status: 400 });
+    }
+
+    const mime = file.type || "";
+    if (!mime.startsWith("image/")) {
+      return new Response(JSON.stringify({ ok: false, error: { message: "Only image uploads are supported" } }), { status: 400 });
+    }
+
+    const size = file.size ?? 0;
+    if (size <= 0 || size > DEFAULT_MAX_IMAGE_BYTES) {
+      return new Response(JSON.stringify({ ok: false, error: { message: `Image size must be >0 and <= ${DEFAULT_MAX_IMAGE_BYTES} bytes` } }), { status: 400 });
+    }
+
+    const ext = (file.name.split(".").pop() || "").toLowerCase();
+    const id = randomUUID();
+    const relDir = path.posix.join("uploads", "banner");
+    const relPath = path.posix.join(relDir, `${id}.${ext || "bin"}`);
+
+    const absDir = path.join(process.cwd(), "public", relDir);
+    const absPath = path.join(process.cwd(), "public", relPath);
+
+    await fs.mkdir(absDir, { recursive: true });
+
+    const arr = new Uint8Array(await file.arrayBuffer());
+    await fs.writeFile(absPath, arr);
+
+    const publicUrl = `/${relPath}`;
+
+    return new Response(JSON.stringify({ ok: true, url: publicUrl }), { status: 200, headers: { "Content-Type": "application/json" } });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : "Internal error";
+    const status = message === "Forbidden" || message === "Unauthorized" ? 403 : 500;
+    return new Response(JSON.stringify({ ok: false, error: { message } }), { status, headers: { "Content-Type": "application/json" } });
+  }
+}

--- a/src/app/api/uploads/local/route.ts
+++ b/src/app/api/uploads/local/route.ts
@@ -1,0 +1,122 @@
+// SPDX-License-Identifier: Apache-2.0
+import { NextRequest } from "next/server";
+import { localStorageService } from "@/lib/local-storage";
+import { ConfigServiceImpl } from "@/lib/config";
+import { db } from "@/lib/db";
+
+function isSafeKey(key: string): boolean {
+  if (!key) return false;
+  // Disallow path traversal and absolute paths
+  if (key.includes("..")) return false;
+  if (key.startsWith("/")) return false;
+  // Basic allowlist for prefixes
+  if (!(key.startsWith("images/") || key.startsWith("videos/") || key.startsWith("uploads/"))) return false;
+  return true;
+}
+
+export async function POST(req: NextRequest) {
+  try {
+    const form = await req.formData();
+    const file = form.get("file");
+    const key = String(form.get("key") || "");
+    const overrideCT = form.get("Content-Type");
+
+    if (!(file instanceof File)) {
+      return new Response(JSON.stringify({ ok: false, error: { code: "NO_FILE", message: "Missing file" } }), {
+        status: 400,
+        headers: { "Content-Type": "application/json" },
+      });
+    }
+
+    if (!isSafeKey(key)) {
+      return new Response(JSON.stringify({ ok: false, error: { code: "INVALID_KEY", message: "Invalid upload key" } }), {
+        status: 400,
+        headers: { "Content-Type": "application/json" },
+      });
+    }
+
+    // Determine content type; prefer explicit override, then file.type, else octet-stream
+    const contentType = typeof overrideCT === "string" && overrideCT ? overrideCT : (file.type || "application/octet-stream");
+
+    // Load validation config to mirror /api/r2/sign behavior
+    const config = new ConfigServiceImpl({ db });
+    const imageMaxBytes = await config.getNumber("UPLOADS.IMAGE-MAX-BYTES");
+    const videoMaxBytes = await config.getNumber("UPLOADS.VIDEO-MAX-BYTES");
+    const allowedImageMimes = (await config.getJSON<string[]>("UPLOADS.ALLOWED-MIME-IMAGE")) ?? [
+      "image/jpeg",
+      "image/png",
+      "image/gif",
+      "image/webp",
+    ];
+    const allowedVideoMimes = (await config.getJSON<string[]>("UPLOADS.ALLOWED-MIME-VIDEO")) ?? [
+      "video/mp4",
+      "video/webm",
+    ];
+
+    if (imageMaxBytes == null || videoMaxBytes == null) {
+      return new Response(
+        JSON.stringify({ ok: false, error: { code: "CONFIG_MISSING", message: "Upload limits not configured" } }),
+        { status: 500, headers: { "Content-Type": "application/json" } }
+      );
+    }
+
+    const isImage = contentType.startsWith("image/") || key.startsWith("images/");
+    const isVideo = contentType.startsWith("video/") || key.startsWith("videos/");
+
+    if (!isImage && !isVideo) {
+      return new Response(
+        JSON.stringify({ ok: false, error: { code: "INVALID_MIME_TYPE", message: "Only image and video files are supported" } }),
+        { status: 400, headers: { "Content-Type": "application/json" } }
+      );
+    }
+
+    // Enforce key prefix consistency where possible
+    if (isImage && key.startsWith("videos/")) {
+      return new Response(
+        JSON.stringify({ ok: false, error: { code: "KEY_TYPE_MISMATCH", message: "Image content must use images/ prefix" } }),
+        { status: 400, headers: { "Content-Type": "application/json" } }
+      );
+    }
+    if (isVideo && key.startsWith("images/")) {
+      return new Response(
+        JSON.stringify({ ok: false, error: { code: "KEY_TYPE_MISMATCH", message: "Video content must use videos/ prefix" } }),
+        { status: 400, headers: { "Content-Type": "application/json" } }
+      );
+    }
+
+    // Validate size against configured max
+    const size = typeof (file as any).size === "number" ? (file as any).size as number : undefined;
+    const maxBytes = isImage ? imageMaxBytes : videoMaxBytes;
+    if (typeof size === "number" && size > maxBytes) {
+      return new Response(
+        JSON.stringify({ ok: false, error: { code: "FILE_TOO_LARGE", message: `File size ${size} exceeds limit of ${maxBytes} bytes` } }),
+        { status: 400, headers: { "Content-Type": "application/json" } }
+      );
+    }
+
+    // Validate MIME allowlist
+    const allowedMimes = isImage ? allowedImageMimes : allowedVideoMimes;
+    if (!allowedMimes.includes(contentType)) {
+      return new Response(
+        JSON.stringify({ ok: false, error: { code: "INVALID_MIME_TYPE", message: `MIME type ${contentType} not allowed` } }),
+        { status: 400, headers: { "Content-Type": "application/json" } }
+      );
+    }
+
+    // Save file to local storage
+    const buf = new Uint8Array(await file.arrayBuffer());
+    await localStorageService.putObject(key, buf, contentType);
+    const url = localStorageService.getPublicUrl(key);
+
+    return new Response(JSON.stringify({ ok: true, url, key }), {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    });
+  } catch (err) {
+    console.error("/api/uploads/local error:", err);
+    return new Response(JSON.stringify({ ok: false, error: { code: "INTERNAL", message: "Upload failed" } }), {
+      status: 500,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+}


### PR DESCRIPTION
This pull request introduces two new API routes for handling file uploads, focusing on secure and configurable support for image and video files. The changes add robust validation, error handling, and integration with both local storage and server configuration.

**New upload API endpoints:**

*Image and banner upload enhancements:*

- Added `src/app/api/uploads/banner/route.ts` to support uploading banner images, restricted to admin users, with checks for file type (image only), file size (max 5MB), and safe file storage in the `public/uploads/banner` directory. Returns a public URL for the uploaded image.

*Configurable and secure local uploads:*

- Added `src/app/api/uploads/local/route.ts` to allow uploading images and videos to local storage with extensive validation:
  - Ensures safe file keys (prevents path traversal, enforces allowed prefixes).
  - Validates file types and MIME types against configurable allowlists and size limits from the database.
  - Enforces consistency between file type and key prefix (e.g., images must use `images/` prefix).
  - Stores files using `localStorageService` and returns a public URL.