### PR TITLE
feat: add honeypot field for spam detection and implement timing vali…

### DIFF
--- a/src/components/comments/CommentForm.tsx
+++ b/src/components/comments/CommentForm.tsx
@@ -37,6 +37,8 @@ export default function CommentForm({
   const [error, setError] = useState<string | null>(null);
   const router = useRouter();
   const textareaRef = useRef<HTMLTextAreaElement | null>(null);
+  const [formStartTime] = useState(() => Date.now()); // Track when form was first rendered
+  const [honeypot, setHoneypot] = useState(""); // Honeypot field for spam detection
 
   // Focus the comment textarea when deep-linked with ?comment=1 or #comment
   useEffect(() => {
@@ -66,11 +68,14 @@ export default function CommentForm({
         parentId,
         bodyMd: bodyMd.trim(),
         attachments,
+        honeypot,
+        submitStartTime: formStartTime,
       });
 
       if (result.success) {
         setBodyMd("");
         setAttachments([]);
+        setHoneypot("");
         onSuccess?.();
         router.refresh(); // Refresh to show the new comment
       } else {
@@ -88,11 +93,26 @@ export default function CommentForm({
     setBodyMd("");
     setAttachments([]);
     setError(null);
+    setHoneypot("");
     onCancel?.();
   };
 
   return (
     <form onSubmit={handleSubmit} className="space-y-4">
+      {/* Honeypot field - hidden from users but visible to bots */}
+      <div style={{ position: 'absolute', left: '-9999px', opacity: 0, pointerEvents: 'none' }} aria-hidden="true">
+        <label htmlFor="website">Website (leave blank):</label>
+        <input
+          type="text"
+          id="website"
+          name="website"
+          value={honeypot}
+          onChange={(e) => setHoneypot(e.target.value)}
+          tabIndex={-1}
+          autoComplete="off"
+        />
+      </div>
+
       {/* Text Area */}
       <div>
         <textarea

--- a/tests/comment-form-timing.test.ts
+++ b/tests/comment-form-timing.test.ts
@@ -1,0 +1,82 @@
+// SPDX-License-Identifier: Apache-2.0
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { validateAntiAbuse } from '@/lib/rateLimit';
+
+describe('Comment Form Timing Fix', () => {
+  beforeEach(() => {
+    // Mock the config service
+    vi.doMock('@/lib/config', () => ({
+      ConfigServiceImpl: class {
+        async getNumber(key: string) {
+          const defaults: Record<string, number> = {
+            'RATE.COMMENTS-PER-MINUTE': 5,
+            'RATE.MIN-SUBMIT-SECS': 2
+          };
+          return Promise.resolve(defaults[key] || null);
+        }
+      }
+    }));
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should allow submission when submitStartTime is properly set and enough time has passed', async () => {
+    const uniqueUserId = `user-${Date.now()}-${Math.random()}`;
+    const formStartTime = Date.now() - 3000; // 3 seconds ago (more than the 2-second minimum)
+
+    const result = await validateAntiAbuse(uniqueUserId, "comment", {
+      honeypot: "", // Empty honeypot (correct)
+      submitStartTime: formStartTime, // Proper start time
+      headers: new Headers({ 'x-real-ip': '192.168.1.1' })
+    });
+
+    expect(result.valid).toBe(true);
+    expect(result.error).toBeUndefined();
+    expect(result.rateLimitInfo?.allowed).toBe(true);
+  });
+
+  it('should reject submission when submitStartTime is null/undefined', async () => {
+    const uniqueUserId = `user-${Date.now()}-${Math.random()}`;
+
+    const result = await validateAntiAbuse(uniqueUserId, "comment", {
+      honeypot: "",
+      submitStartTime: null, // This was the original bug
+      headers: new Headers({ 'x-real-ip': '192.168.1.1' })
+    });
+
+    expect(result.valid).toBe(false);
+    expect(result.error).toContain("Submission too fast");
+    expect(result.error).toContain("2 seconds");
+  });
+
+  it('should reject submission when not enough time has passed since form load', async () => {
+    const uniqueUserId = `user-${Date.now()}-${Math.random()}`;
+    const formStartTime = Date.now() - 500; // Only 0.5 seconds ago (less than 2-second minimum)
+
+    const result = await validateAntiAbuse(uniqueUserId, "comment", {
+      honeypot: "",
+      submitStartTime: formStartTime,
+      headers: new Headers({ 'x-real-ip': '192.168.1.1' })
+    });
+
+    expect(result.valid).toBe(false);
+    expect(result.error).toContain("Submission too fast");
+    expect(result.error).toContain("2 seconds");
+  });
+
+  it('should reject submission when honeypot is filled', async () => {
+    const uniqueUserId = `user-${Date.now()}-${Math.random()}`;
+    const formStartTime = Date.now() - 3000; // Proper timing
+
+    const result = await validateAntiAbuse(uniqueUserId, "comment", {
+      honeypot: "spam-content", // Honeypot filled (indicates bot)
+      submitStartTime: formStartTime,
+      headers: new Headers({ 'x-real-ip': '192.168.1.1' })
+    });
+
+    expect(result.valid).toBe(false);
+    expect(result.error).toBe("Invalid form submission");
+  });
+});


### PR DESCRIPTION
This pull request enhances the comment form's anti-abuse mechanisms by introducing a honeypot field to detect bots and by tracking the time when the form was first rendered to prevent too-rapid submissions. Additionally, comprehensive tests have been added to ensure these protections work as intended.

**Anti-abuse improvements in the comment form:**

* Added a hidden honeypot field (`honeypot`) to `CommentForm.tsx` to trap bots that autofill fields not visible to users. The field is reset after successful submission or cancellation. [[1]](diffhunk://#diff-5620b03f3a13d6a5622c928ca2d3963883c0f1cd7d811dbb6ead7dbba88e2713R40-R41) [[2]](diffhunk://#diff-5620b03f3a13d6a5622c928ca2d3963883c0f1cd7d811dbb6ead7dbba88e2713R96-R115)
* Tracked the form's initial render time (`formStartTime`) and included it in the submission payload to enforce a minimum time before a comment can be submitted, helping to block automated spam. [[1]](diffhunk://#diff-5620b03f3a13d6a5622c928ca2d3963883c0f1cd7d811dbb6ead7dbba88e2713R40-R41) [[2]](diffhunk://#diff-5620b03f3a13d6a5622c928ca2d3963883c0f1cd7d811dbb6ead7dbba88e2713R71-R78)

**Testing enhancements:**

* Introduced a new test file `comment-form-timing.test.ts` to verify the anti-abuse logic, including checks for minimum submission time and honeypot field validation.…dation tests for comment submissions

### Summary
<!-- What changed and why -->

### Type of Change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality) 
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

### Release note
- [ ] I ran `pnpm changeset` and added a short note with the appropriate bump type.
- [ ] If this PR is docs/chore-only, explain why no changeset is needed.

### Testing
- [ ] I have tested this change locally
- [ ] I have updated tests as needed
- [ ] All tests pass (`pnpm test`)

<!-- 
For changeset guidance:
- `patch` for bug fixes, small improvements
- `minor` for new features, backwards-compatible changes  
- `major` for breaking changes

Run: pnpm changeset
Choose the bump type and write a brief description for the changelog.
-->