### PR TITLE
feat: update version to 0.4.0 and enhance comment auto-approval tests…

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,10 +1,11 @@
 {
   "name": "narravo-next",
   "private": true,
-  "version": "0.3.0",
+  "version": "0.4.0",
   "tiptap-markdown": "0.9.0",
   "license": "Apache-2.0",
   "scripts": {
+    "pretypecheck": "node scripts/write-version.mjs",
     "typecheck": "tsc --noEmit",
     "dev": "next dev",
     "prebuild": "node scripts/write-version.mjs",

--- a/tests/comment-auto-approval.test.ts
+++ b/tests/comment-auto-approval.test.ts
@@ -1,6 +1,12 @@
 // SPDX-License-Identifier: Apache-2.0
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { createComment } from '@/components/comments/actions';
+import { requireSession } from '@/lib/auth';
+import { ConfigServiceImpl } from '@/lib/config';
+import { createCommentCore } from '@/lib/comments';
+import { validateAntiAbuse } from '@/lib/rateLimit';
+import { headers } from 'next/headers';
+import { db } from '@/lib/db';
 
 // Mock the dependencies
 vi.mock('@/lib/auth', () => ({
@@ -16,14 +22,22 @@ vi.mock('@/lib/config', () => ({
 
 vi.mock('@/lib/db', () => ({
   db: {
-    select: vi.fn(),
-    insert: vi.fn(),
+    select: vi.fn().mockReturnThis(),
+    from: vi.fn().mockReturnThis(),
+    where: vi.fn().mockReturnThis(),
+    limit: vi.fn(),
+    insert: vi.fn().mockReturnThis(),
+    values: vi.fn().mockReturnThis(),
+    returning: vi.fn(),
   },
 }));
 
 vi.mock('@/lib/comments', () => ({
   createCommentCore: vi.fn(),
-  sanitizeMarkdown: vi.fn(),
+}));
+
+vi.mock('@/lib/rateLimit', () => ({
+  validateAntiAbuse: vi.fn(),
 }));
 
 vi.mock('next/cache', () => ({
@@ -35,18 +49,29 @@ vi.mock('next/headers', () => ({
 }));
 
 describe('Comment Auto-Approval', () => {
-  const mockRequireSession = vi.mocked(require('@/lib/auth').requireSession);
-  const mockConfigService = vi.mocked(require('@/lib/config').ConfigServiceImpl);
-  const mockCreateCommentCore = vi.mocked(require('@/lib/comments').createCommentCore);
+  const mockRequireSession = vi.mocked(requireSession);
+  const mockConfigService = vi.mocked(ConfigServiceImpl);
+  const mockCreateCommentCore = vi.mocked(createCommentCore);
+  const mockValidateAntiAbuse = vi.mocked(validateAntiAbuse);
 
   beforeEach(() => {
     vi.clearAllMocks();
     
     // Mock headers
-    require('next/headers').headers.mockResolvedValue(new Headers());
+    vi.mocked(headers).mockResolvedValue(new Headers());
     
     // Mock successful comment creation
     mockCreateCommentCore.mockResolvedValue({ id: 'test-comment-id' });
+    
+    // Mock successful anti-abuse validation
+    mockValidateAntiAbuse.mockResolvedValue({ valid: true });
+    
+    // Mock database operations
+    const mockDb = vi.mocked(db);
+    // Mock post exists check - return a post
+    mockDb.select().from().where().limit.mockResolvedValue([{ id: 'test-post-id' }]);
+    // Mock comment insert - return comment id
+    mockDb.insert().values().returning.mockResolvedValue([{ id: 'test-comment-id' }]);
   });
 
   afterEach(() => {
@@ -56,7 +81,8 @@ describe('Comment Auto-Approval', () => {
   it('should auto-approve comments from admin users', async () => {
     // Mock admin user session
     mockRequireSession.mockResolvedValue({
-      user: { id: 'admin-user-id', isAdmin: true }
+      user: { id: 'admin-user-id', isAdmin: true },
+      expires: new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString()
     });
 
     // Mock config - auto-approve disabled but user is admin
@@ -64,7 +90,7 @@ describe('Comment Auto-Approval', () => {
       getNumber: vi.fn().mockResolvedValue(5), // MAX-DEPTH
       getBoolean: vi.fn().mockResolvedValue(false), // AUTO-APPROVE off
     };
-    mockConfigService.mockReturnValue(mockConfigInstance);
+    (mockConfigService as any).mockReturnValue(mockConfigInstance);
 
     let capturedCommentData: any = null;
     mockCreateCommentCore.mockImplementation(async (deps: any, data: any) => {
@@ -85,14 +111,15 @@ describe('Comment Auto-Approval', () => {
     expect(mockCreateCommentCore).toHaveBeenCalled();
     
     // Verify that the insertComment function was called and would insert with 'approved' status
-    const insertCommentFn = mockCreateCommentCore.mock.calls[0][0].insertComment;
+    const insertCommentFn = mockCreateCommentCore.mock.calls[0]?.[0]?.insertComment;
     expect(insertCommentFn).toBeDefined();
   });
 
   it('should auto-approve comments when AUTO-APPROVE is enabled', async () => {
     // Mock regular user session
     mockRequireSession.mockResolvedValue({
-      user: { id: 'regular-user-id', isAdmin: false }
+      user: { id: 'regular-user-id', isAdmin: false },
+      expires: new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString()
     });
 
     // Mock config - auto-approve enabled
@@ -100,7 +127,7 @@ describe('Comment Auto-Approval', () => {
       getNumber: vi.fn().mockResolvedValue(5), // MAX-DEPTH
       getBoolean: vi.fn().mockResolvedValue(true), // AUTO-APPROVE on
     };
-    mockConfigService.mockReturnValue(mockConfigInstance);
+    (mockConfigService as any).mockReturnValue(mockConfigInstance);
 
     mockCreateCommentCore.mockImplementation(async (deps: any, data: any) => {
       // Capture the comment data that would be inserted
@@ -123,7 +150,8 @@ describe('Comment Auto-Approval', () => {
   it('should require moderation for regular users when auto-approve is disabled', async () => {
     // Mock regular user session
     mockRequireSession.mockResolvedValue({
-      user: { id: 'regular-user-id', isAdmin: false }
+      user: { id: 'regular-user-id', isAdmin: false },
+      expires: new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString()
     });
 
     // Mock config - auto-approve disabled
@@ -131,7 +159,7 @@ describe('Comment Auto-Approval', () => {
       getNumber: vi.fn().mockResolvedValue(5), // MAX-DEPTH
       getBoolean: vi.fn().mockResolvedValue(false), // AUTO-APPROVE off
     };
-    mockConfigService.mockReturnValue(mockConfigInstance);
+    (mockConfigService as any).mockReturnValue(mockConfigInstance);
 
     mockCreateCommentCore.mockImplementation(async (deps: any, data: any) => {
       // Capture the comment data that would be inserted


### PR DESCRIPTION
This pull request primarily improves the test setup for comment auto-approval by enhancing the mocking of dependencies and updating test user session objects to include expiration dates. These changes make the tests more robust and realistic, ensuring that all external dependencies are properly mocked and that session objects match expected structures.

**Test infrastructure improvements:**

* Enhanced the mocking of the `db` object in `tests/comment-auto-approval.test.ts` to support method chaining for `select`, `from`, `where`, `insert`, `values`, and `returning`, allowing for more accurate simulation of database operations.
* Added mocks for `validateAntiAbuse` from `@/lib/rateLimit` and improved the usage of mocked dependencies throughout the test file, including `requireSession`, `ConfigServiceImpl`, and `createCommentCore`. [[1]](diffhunk://#diff-22b76a07ea1e74b8568daa427fdf2ca60ab110e8e9ed6567b1767ae63961c7eeR4-R9) [[2]](diffhunk://#diff-22b76a07ea1e74b8568daa427fdf2ca60ab110e8e9ed6567b1767ae63961c7eeL19-R40) [[3]](diffhunk://#diff-22b76a07ea1e74b8568daa427fdf2ca60ab110e8e9ed6567b1767ae63961c7eeL38-R74)
* Updated test setup in `beforeEach` to mock database queries and anti-abuse validation results, ensuring each test runs with predictable, isolated state.

**Test logic and data improvements:**

* Modified test user session objects to include an `expires` field, matching the expected session structure and improving test accuracy. [[1]](diffhunk://#diff-22b76a07ea1e74b8568daa427fdf2ca60ab110e8e9ed6567b1767ae63961c7eeL59-R93) [[2]](diffhunk://#diff-22b76a07ea1e74b8568daa427fdf2ca60ab110e8e9ed6567b1767ae63961c7eeL88-R130) [[3]](diffhunk://#diff-22b76a07ea1e74b8568daa427fdf2ca60ab110e8e9ed6567b1767ae63961c7eeL126-R162)
* Updated assertions and test logic to handle potentially undefined values more safely, increasing test reliability.

**Other changes:**

* Updated the project version in `package.json` from `0.3.0` to `0.4.0` and added a `pretypecheck` script for writing the version before type checking.… with session expiration handling

### Summary
<!-- What changed and why -->

### Type of Change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality) 
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

### Release note
- [ ] I ran `pnpm changeset` and added a short note with the appropriate bump type.
- [ ] If this PR is docs/chore-only, explain why no changeset is needed.

### Testing
- [ ] I have tested this change locally
- [ ] I have updated tests as needed
- [ ] All tests pass (`pnpm test`)

<!-- 
For changeset guidance:
- `patch` for bug fixes, small improvements
- `minor` for new features, backwards-compatible changes  
- `major` for breaking changes

Run: pnpm changeset
Choose the bump type and write a brief description for the changelog.
-->